### PR TITLE
Refactor sim

### DIFF
--- a/docs/src/history_recorder.md
+++ b/docs/src/history_recorder.md
@@ -10,6 +10,8 @@ policy = RandomPolicy(pomdp)
 h = simulate(hr, pomdp, policy)
 ```
 
+More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb).
+
 ```@docs
 HistoryRecorder
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,8 @@
 # Home
 
-POMDPSimulators is a collection of utilities for simulating [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl) models. [TODO: add link to standard]
+POMDPSimulators is a collection of utilities for simulating [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl) models. All of the simulators in this package should conform to the POMDPs.jl [Simulation Standard](http://juliapomdp.github.io/POMDPs.jl/latest/simulation.html#Simulation-Standard-1).
+
+Examples can be found in the [simulation tutorial in the POMDPExamples package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb).
 
 If you are just getting started, probably the easiest way to begin is the [`stepthrough` function](@ref Stepping-through). Otherwise, consult the [Which Simulator Should I Use?](@ref) page.
 

--- a/docs/src/parallel.md
+++ b/docs/src/parallel.md
@@ -27,45 +27,7 @@ would compute the average reward per step with each simulation weighted equally 
 
 ## Example
 
-```julia
-using POMDPModels
-using POMDPPolicies
-using POMDPSimulators
-
-pomdp = BabyPOMDP()
-fwc = FeedWhenCrying()
-rnd = solve(RandomSolver(MersenneTwister(7)), pomdp)
-
-q = [] # vector of the simulations to be run
-push!(q, Sim(pomdp, fwc, max_steps=32, rng=MersenneTwister(4), metadata=Dict(:policy=>"feed when crying")))
-push!(q, Sim(pomdp, rnd, max_steps=32, rng=MersenneTwister(4), metadata=Dict(:policy=>"random")))
-
-# this creates two simulations, one with the feed-when-crying policy and one with a random policy
-
-data = run_parallel(q)
-
-# by default, the dataframe output contains the reward and the contents of `metadata`
-@show data
-# data = 2×2 DataFrames.DataFrame
-# │ Row │ policy             │ reward   │
-# ├─────┼────────────────────┼──────────┤
-# │ 1   │ "feed when crying" │ -4.5874  │
-# │ 2   │ "random"           │ -27.4139 │
-
-# to perform additional analysis on each of the simulations one can define a processing function with the `do` syntax:
-data2 = run_parallel(q, progress=false) do sim, hist
-println("finished a simulation - final state was $(last(state_hist(hist)))")
-return [:steps=>n_steps(hist), :reward=>discounted_reward(hist)]
-end
-
-@show data2
-# 2×3 DataFrames.DataFrame
-# │ Row │ policy             │ reward   │ steps │
-# ├─────┼────────────────────┼──────────┼───────┤
-# │ 1   │ "feed when crying" │ -18.2874 │ 32.0  │
-# │ 2   │ "random"           │ -17.7054 │ 32.0  │
-
-```
+Examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb)
 
 ## Sim objects
 

--- a/docs/src/rollout.md
+++ b/docs/src/rollout.md
@@ -12,6 +12,8 @@ policy = RandomPolicy(mdp)
 r = simulate(rs, mdp, policy)
 ```
 
+More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb)
+
 ```@docs
 RolloutSimulator
 ```

--- a/docs/src/sim.md
+++ b/docs/src/sim.md
@@ -11,6 +11,8 @@ end
 ```
 This allows a flexible and general way to interact with a POMDP environment without creating new `Policy` types.
 
+In the POMDP case, an updater can optionally be supplied as an additional positional argument if the policy function works with beliefs rather than directly with observations.
+
 More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb)
 
 ```@docs

--- a/docs/src/sim.md
+++ b/docs/src/sim.md
@@ -13,6 +13,8 @@ This allows a flexible and general way to interact with a POMDP environment with
 
 Note: by default, since there is no observation before the first action, on the first call to the `do` block, `obs` is `nothing`.
 
+More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb)
+
 ```@docs
 sim
 ```

--- a/docs/src/sim.md
+++ b/docs/src/sim.md
@@ -11,8 +11,6 @@ end
 ```
 This allows a flexible and general way to interact with a POMDP environment without creating new `Policy` types.
 
-Note: by default, since there is no observation before the first action, on the first call to the `do` block, `obs` is `nothing`.
-
 More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb)
 
 ```@docs

--- a/docs/src/stepthrough.md
+++ b/docs/src/stepthrough.md
@@ -13,6 +13,8 @@ for (s, a, o, r) in stepthrough(pomdp, policy, "s,a,o,r", max_steps=10)
 end
 ```
 
+More examples can be found in the [POMDPExamples Package](https://github.com/JuliaPOMDP/POMDPExamples.jl/blob/master/notebooks/Running-Simulations.ipynb).
+
 ```@docs
 stepthrough
 ```

--- a/test/test_sim.jl
+++ b/test/test_sim.jl
@@ -30,4 +30,11 @@ end
         return rand(acts)
     end
     @test length(hist) == 100
+
+    hist = sim(pomdp, max_steps=100, DiscreteUpdater(pomdp)) do b
+        @assert isa(b, DiscreteBelief)
+        acts = actions(pomdp)
+        return rand(acts)
+    end
+
 end

--- a/test/test_sim.jl
+++ b/test/test_sim.jl
@@ -12,7 +12,7 @@ end
 
 @testset "BabyPOMDP sim" begin 
     pomdp = BabyPOMDP()
-    hist = sim(pomdp, max_steps=100) do obs
+    hist = sim(pomdp, max_steps=100, initialobs=false) do obs
         @assert isa(obs, Bool)
         acts = actions(pomdp)
         return rand(acts)
@@ -20,14 +20,12 @@ end
     @test length(hist) == 100
 
     hist = sim(pomdp, false, max_steps=100) do obs
-        @assert isa(obs, Bool)
         acts = actions(pomdp)
         return rand(acts)
     end
     @test length(hist) == 100
 
     hist = sim(pomdp, initialstate=true, max_steps=100) do obs
-        @assert isa(obs, Bool)
         acts = actions(pomdp)
         return rand(acts)
     end


### PR DESCRIPTION
I'm not sure if anyone else really uses the `sim` function, but I started to find it annoying and inconsistent. This PR makes two changes.

1. The only positional argument (besides the policy function which will usually be implemented with `do`) is the mdp or pompd; `initialstate` is now a keyword argument. There is a deprecation warning to help with this
2. If the `initialobs` keyword argument is not present, the following sequence of defaults are tried:
  1. `initialstate_distribution(...)`
  2. `generate_o(m, s, rng)`
  3. `missing`

Having the initial observation be a state distribution by default may be a little unexpected, but I think it actually makes the most sense.

Comments welcome (but I expect few others have thought much about it)