### PR TITLE
run_parallel uses pmap and handle worker ids correctly

### DIFF
--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -127,6 +127,11 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
              To use multiple processes, use addprocs() or the -p option (e.g. julia -p 4) and make sure the correct worker pool is assigned to argument `pool` in the call to run_parallel.
              """)
     end
+    
+    if progress in (nothing, false)
+        @warn("run_parallel(..., progress=$progress) is deprecated. Use run_parallel(..., show_progress=false) instead.")
+        show_progress = Bool
+    end
 
     map_function = (args...) -> (show_progress ?
                                  progress_pmap(args..., progress=progress) : pmap(args...))

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -128,7 +128,9 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
              """)
     end
 
-    frame_lines = progress_pmap(pool, queue) do sim
+    map_fun = progress isa Progress ? progress_pmap : pmap
+
+    frame_lines = map_fun(pool, queue) do sim
         result = simulate(sim)
         output = process(sim, result)
         return merge(sim.metadata, output)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -103,7 +103,8 @@ By default, the `DataFrame` will contain the reward for each simulation and the 
 This function should take two arguments, (1) the `Sim` that was executed and (2) the result of the simulation, by default a `SimHistory`. It should return a named tuple that will appear in the dataframe. See Examples below.
 
 ## Keyword Arguments
-- `progress`: a `ProgressMeter.Progress` for showing progress through the simulations; `progress=false` will suppress the progress meter
+- `show_progress::Bool`: whether or not to show a progress meter
+- `progress::ProgressMeter.Progress`: determines how the progress meter is displayed
 
 # Examples
 
@@ -129,13 +130,13 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
     end
     
     if progress in (nothing, false)
-        progstr = progress == nothing ? "nothing" : "false"
+        progstr = (progress == nothing) ? "nothing" : "false"
         @warn("run_parallel(..., progress=$progstr) is deprecated. Use run_parallel(..., show_progress=false) instead.")
-        show_progress = Bool
+        show_progress = false
     end
 
-    map_function = (args...) -> (show_progress ?
-                                 progress_pmap(args..., progress=progress) : pmap(args...))
+    map_function(args...) = (show_progress ?
+                             progress_pmap(args..., progress=progress) : pmap(args...))
 
     frame_lines = map_function(pool, queue) do sim
         result = simulate(sim)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -116,7 +116,7 @@ will return a dataframe with with the number of steps and the reward in it.
 """
 function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWorkerPool=default_worker_pool();
                       progress=Progress(length(queue), desc="Simulating..."),
-                      proc_warn=true)
+                      proc_warn::Bool=true, show_progress::Bool=true)
 
     if nworkers(pool) == 1 && proc_warn
         @warn("""
@@ -128,9 +128,10 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
              """)
     end
 
-    map_fun = progress isa Progress ? progress_pmap : pmap
+    map_function = (args...) -> (show_progress ?
+                                 progress_pmap(args..., progress=progress) : pmap(args...))
 
-    frame_lines = map_fun(pool, queue) do sim
+    frame_lines = map_function(pool, queue) do sim
         result = simulate(sim)
         output = process(sim, result)
         return merge(sim.metadata, output)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -129,7 +129,8 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
     end
     
     if progress in (nothing, false)
-        @warn("run_parallel(..., progress=$progress) is deprecated. Use run_parallel(..., show_progress=false) instead.")
+        progstr = progress == nothing ? "nothing" : "false"
+        @warn("run_parallel(..., progress=$progstr) is deprecated. Use run_parallel(..., show_progress=false) instead.")
         show_progress = Bool
     end
 

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -10,14 +10,12 @@ let
     push!(q, Sim(pomdp, fwc, max_steps=32, rng=MersenneTwister(4), metadata=Dict(:policy=>"feed when crying")))
     push!(q, Sim(pomdp, rnd, max_steps=32, rng=MersenneTwister(4), metadata=(policy="random",)))
 
-    println("There should be a warning here:")
-    run_parallel(q)
+    @test_logs (:warn,) run_parallel(q, progress=nothing)
 
-    procs = addprocs(1)
+    procs = addprocs(2)
     @everywhere using POMDPSimulators
     @everywhere using POMDPModels
-    println("There should not be a warning here:")
-    @show run_parallel(q) do sim, hist
+    @test_nowarn @show run_parallel(q, progress=nothing) do sim, hist
         return (steps=n_steps(hist), reward=discounted_reward(hist))
     end
 

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -10,12 +10,12 @@ let
     push!(q, Sim(pomdp, fwc, max_steps=32, rng=MersenneTwister(4), metadata=Dict(:policy=>"feed when crying")))
     push!(q, Sim(pomdp, rnd, max_steps=32, rng=MersenneTwister(4), metadata=(policy="random",)))
 
-    @test_logs (:warn,) run_parallel(q, progress=nothing)
+    @test_logs (:warn,) run_parallel(q, show_progress=false)
 
     procs = addprocs(2)
     @everywhere using POMDPSimulators
     @everywhere using POMDPModels
-    @test_nowarn @show run_parallel(q, progress=nothing) do sim, hist
+    @test_nowarn @show run_parallel(q, show_progress=false) do sim, hist
         return (steps=n_steps(hist), reward=discounted_reward(hist))
     end
 
@@ -56,7 +56,7 @@ let
     # │ 2   │ "random"           │ -27.4139 │
 
     # to perform additional analysis on each of the simulations one can define a processing function with the `do` syntax:
-    data2 = run_parallel(q, progress=false) do sim, hist
+    data2 = run_parallel(q, show_progress=false) do sim, hist
         println("finished a simulation - final state was $(last(state_hist(hist)))")
         return (steps=n_steps(hist), reward=discounted_reward(hist))
     end

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -15,6 +15,10 @@ let
     procs = addprocs(2)
     @everywhere using POMDPSimulators
     @everywhere using POMDPModels
+    
+    # test progress=nothing deprecation
+    @test_logs (:warn,) run_parallel(q, progress=nothing)
+    
     @test_nowarn @show run_parallel(q, show_progress=false) do sim, hist
         return (steps=n_steps(hist), reward=discounted_reward(hist))
     end


### PR DESCRIPTION
- use `progress_pmap` from [`ProgressMeters.jl`](https://github.com/timholy/ProgressMeter.jl)
- introduc `pool` argument to specify the worker pool
- fix the bug of wrong worker id's by iterating over `pool` instead of `1:nprocs()` (not all ID's must be occupied, e.g. if workers were killed).
- update warning to match the new behavior