### PR TITLE
Use Random.GLOBAL_RNG as rng default

### DIFF
--- a/src/history_recorder.jl
+++ b/src/history_recorder.jl
@@ -34,7 +34,7 @@ mutable struct HistoryRecorder <: Simulator
 end
 
 # This is the only stable constructor
-function HistoryRecorder(;rng=MersenneTwister(rand(UInt32)),
+function HistoryRecorder(;rng=Random.GLOBAL_RNG,
                           eps=nothing,
                           max_steps=nothing,
                           capture_exception=false,


### PR DESCRIPTION
The `HistoryRecorder` now also uses `Random.GLOBAL_RNG` as `rng` default to allow users to fully determinize the output by calling `Random.seed!(x::UInt)`.