### PR TITLE
Update POMDPSimulators.jl

### DIFF
--- a/src/POMDPSimulators.jl
+++ b/src/POMDPSimulators.jl
@@ -17,10 +17,6 @@ include("rollout.jl")
 
 export
     SimHistory,
-    POMDPHistory,
-    MDPHistory,
-    AbstractPOMDPHistory,
-    AbstractMDPHistory,
     HistoryIterator,
     eachstep,
     state_hist,


### PR DESCRIPTION
Per a conversation with @ebalaban yesterday, I think these exports should be removed.