### PR TITLE
Update :info symbol

### DIFF
--- a/src/history.jl
+++ b/src/history.jl
@@ -40,7 +40,7 @@ action_hist(h::AbstractSimHistory) = h[:a]
 observation_hist(h::AbstractSimHistory) = h[:o]
 belief_hist(h::AbstractSimHistory) = push!([step.b for step in hist(h)], last(hist(h)).bp)
 reward_hist(h::AbstractSimHistory) = h[:r]
-info_hist(h::AbstractSimHistory) = h[:i]
+info_hist(h::AbstractSimHistory) = h[:info]
 ainfo_hist(h::AbstractSimHistory) = h[:action_info]
 uinfo_hist(h::AbstractSimHistory) = h[:update_info]
 


### PR DESCRIPTION
It seems `:i` was previously used for info where `:info` is used now.

Example:

```
using POMDPSimulators, POMDPs, POMDPModels, POMDPPolicies
hr = HistoryRecorder(max_steps=10)
hist = simulate(hr, BabyPOMDP(), FunctionPolicy(x->true))

collect(info_hist(hist)) # currently fails

step = hist[1]
step[:info] # works
step[:i] # fails
```